### PR TITLE
Fix type issues with ValidationKeyGetter.

### DIFF
--- a/00-Starter-Seed/main.go
+++ b/00-Starter-Seed/main.go
@@ -28,11 +28,11 @@ func StartServer() {
 
 	jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
 		ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
-			token, err := os.Getenv("AUTH0_CLIENT_SECRET")
-			if err != nil {
-				return nil, err
+			secret := os.Getenv("AUTH0_CLIENT_SECRET")			
+			if secret != "" {
+				return nil, errors.New("AUTH0_CLIENT_SECRET is not set")
 			}
-			return token, nil
+			return secret, nil
 		},
 	})
 


### PR DESCRIPTION
Sample does not run as is.  Fixed the following:

os.Getenv returns a string and no errors, creating an unmatched variable.
Changes token to secret since we're looking for the secret to be used for Validation, not modify the token passed in.