### PR TITLE
fixed compilation error due to error creation

### DIFF
--- a/00-Starter-Seed/main.go
+++ b/00-Starter-Seed/main.go
@@ -30,7 +30,7 @@ func StartServer() {
           ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
             secret := os.Getenv("AUTH0_CLIENT_SECRET")			
             if secret == "" {
-              return nil, errors.New("AUTH0_CLIENT_SECRET is not set")
+              log.Fatal("AUTH0_CLIENT_SECRET is not set")
             }
             return secret, nil
           },


### PR DESCRIPTION
This small patch is loosely related to Issue #5 in this repo. Original sample app would not compile. Error creation replaced with a Fatal log, maintaining consistency with the behaviour of a missing .env file.